### PR TITLE
Scripting update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.xml
 physOffsets
 his
+errors.log
 
 #Backup files from various editors
 *.save

--- a/config.bash
+++ b/config.bash
@@ -22,11 +22,11 @@
 
 #---------- Path and Histogram Information ----------
 #Sets the histogram to be used for the time calibration
-his="<PATH/TO/HIS>"
+#---his="<PATH/TO/HIS>"
 #Sets the path for the results
-resultDir="<PATH/TO/RESULTDIR>"
+#---resultDir="<PATH/TO/RESULTDIR>"
 #Sets the path for the physical offsets of the bars
-physOffsetDir="<PATH/TO/TIMECALINSTALL>/phys/ornl2016"
+physOffsetDir="$timecalInstallDir/phys/ornl2016"
 #---------- Fitting Configuration ---------
 #Sets the minimum statistics required for fitting the spectra
 minStats=100

--- a/config.bash
+++ b/config.bash
@@ -22,12 +22,11 @@
 
 #---------- Path and Histogram Information ----------
 #Sets the histogram to be used for the time calibration
-his="/home/is632/OFFLINE_SCAN/timecal"
+his="<PATH/TO/HIS>"
 #Sets the path for the results
-resultDir="/home/is632/OFFLINE_SCAN/timecal"
+resultDir="<PATH/TO/RESULTDIR>"
 #Sets the path for the physical offsets of the bars
-physOffsetDir="phys/is632"
-
+physOffsetDir="<PATH/TO/TIMECALINSTALL>/phys/ornl2016"
 #---------- Fitting Configuration ---------
 #Sets the minimum statistics required for fitting the spectra
 minStats=100
@@ -44,7 +43,7 @@ smallOffsets="small.dat"
 
 #---------- Medium Bar Information ----------
 #The number of medium VANDLE bars that are in the analysis
-numMediumBars=26
+numMediumBars=42
 #The file containing the small offsets 
 mediumOffsets="medium.dat"
 
@@ -56,7 +55,7 @@ bigOffsets="big.dat"
 
 #---------- Histogram Information ----------
 #Offset for VANDLE histograms
-vandleOffset=3200
+vandleOffset=3300
 #Base Offset for the Time Difference
 vandleTdiffBaseId=2
 #Base Offset for the Time of Flight
@@ -64,7 +63,7 @@ vandleTofBaseId=3
 #The DAMM ID offset for small VANDLE bars
 smallOffset=0
 #The DAMM ID offset for medium VANDLE bars
-mediumOffset=40
+mediumOffset=10
 #The DAMM ID offset for big VANDLE bars
 bigOffset=20
 #VANDLE Histogram Resolution (bins/ns)

--- a/timeCal.bash
+++ b/timeCal.bash
@@ -45,7 +45,7 @@ fi
 if [ ! -d "$resultDir" ]
 then
     echo -e "Result directory missing, creating..."
-2    mkdir -p $resultDir
+    mkdir -p $resultDir
 fi
 
 if [ ! -d "$physOffsetDir" ]

--- a/timeCal.bash
+++ b/timeCal.bash
@@ -23,17 +23,18 @@ errorLog="errors.log"
 rm $errorLog > /dev/null 2>&1
 skippedCount=0
 
-source config.bash
+timecalInstallDir=${HOME}/programs/timeCal
+
+source $timecalInstallDir/config.bash
 
 if [ ! -z $1 ]
 then
-   his="$1" 
-   hisbase=`basename $his .his`
-
-   if [ ! -z $2 ]
-   then
-       resultDir=$2/$hisbase
-   fi
+    his="$1" 
+    hisbase=`basename $his .his`
+    if [ ! -z $2 ]
+    then
+	resultDir=$2/$hisbase
+    fi
 fi
 
 if [ ! -d "$tmpDir" ]
@@ -44,7 +45,7 @@ fi
 if [ ! -d "$resultDir" ]
 then
     echo -e "Result directory missing, creating..."
-    mkdir -p $resultDir
+2    mkdir -p $resultDir
 fi
 
 if [ ! -d "$physOffsetDir" ]
@@ -97,7 +98,7 @@ PerformFit() {
     ProjectSpectra
     if [ "$hasEnoughStats" = true ]
     then
-        gnuplot timeCal.gp > /dev/null 2>&1 && fitRes=`cat $tempFitResults`
+        gnuplot $timecalInstallDir/timeCal.gp > /dev/null 2>&1 && fitRes=`cat $tempFitResults`
     else
         fitRes=0
     fi


### PR DESCRIPTION
Allows timeCal.bash to run from other directories for easier scripting. also updated the .gitignore to ignore the error log. This also sets the histograms to the new permanent uncaled vandle histograms in paass.